### PR TITLE
Add a Simple GPU hello-world example

### DIFF
--- a/gpu-hello-world.rst
+++ b/gpu-hello-world.rst
@@ -1,0 +1,121 @@
+=========================
+A hello world GPU example
+=========================
+
+This guide should show you all the steps required for creating a simple GPU-based application. It is recommended that the reader familiarize themselves with :ref:`hello-world` and the other parts of the :ref:`user-guide` before getting started.
+
+Clone the example project:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/zalando-stups/gpu-hello-world.git
+    $ cd gpu-hello-world
+
+Create this new application using the :ref:`yourturn` web frontend:
+
+.. code-block:: bash
+
+    https://yourturn.stups.example.org
+
+Now you will need to create the :ref:`scm-source-json` file that links your Docker image to a specific git revision number (here the `scm-source Python package <https://pypi.python.org/pypi/scm-source`_ is used):
+
+.. code-block:: bash
+
+    $ scm-source
+
+Build the Docker image
+
+.. code-block:: bash
+
+    $ docker build -t pierone.stups.example.org/<your-team>/gpu-hello-world:0.1 .
+
+And now see if it is listed locally:
+
+.. code-block:: bash
+
+    $ docker images
+
+If you have `nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ installed locally, the image can also be run:
+
+.. code-block:: bash
+
+    $ docker run --rm -it pierone.stups.example.org/<your-team>/gpu-hello-world:0.1
+
+which should show the expected output from `nvidia-smi`.
+
+.. Note::
+
+    Running with `docker` instead of `nvidia-docker` will show a `/bin/sh: 1: nvidia-smi: not found` message as the `nvidia-smi` tool used is part of the NVIDIA CUDA driver installiation which is not available when running with `docker`.
+
+If all works, we are ready to login in :ref:`pierone` and push it.
+
+.. code-block:: bash
+
+    $ pierone login
+    $ docker push pierone.stups.example.org/<your-team>/gpu-hello-world:0.1
+
+Let's check if we can find it in the Pier One repository (login needed if your token expired):
+
+.. code-block:: bash
+
+    $ pierone login
+    $ pierone tags <your-team> gpu-hello-world
+
+Now let's create the version in YOUR TURN for the application created:
+
+.. code-block:: bash
+
+    https://yourturn.stups.example.org
+
+Configure your application's mint bucket (click on the "Access Control" button on your app's page in YOUR TURN).
+
+This will trigger the mint worker to write your app credentials to your mint bucket.
+
+Deploy!
+
+Create a :ref:`senza` definition file for that (using the region you are on):
+
+.. code-block:: bash
+
+    $ senza init --region eu-west-1 deploy-definition.yaml
+
+* Choose the "bgapp" template.
+* Enter the application ID "gpu-hello-world"
+* Enter the docker image "pierone.stups.example.org/<your-team>/gpu-hello-world"
+* Go for "p2.xlarge" (This has a single K80 GPU installed)
+* Use the default mint bucket
+
+After this, you can also add a log provider or other configuration options (like :ref:`guide <spot-pricing>`).
+
+Create your Cloud Formation stack.
+
+.. code-block:: bash
+
+    $ senza create deploy-definition.yaml stackversion 0.1 --region=eu-west-1
+
+* Senza will generate CF JSON
+* CF stack is created
+* ASG launches Taupage instance
+* Taupage starts Scalyr agent
+* Taupage runs berry to download app credentials
+* Taupage pushes Taupage config userdata to fullstop.
+* Taupage pulls Docker image from Pier One using the app credentials
+* Taupage starts the Docker container
+* Taupage signals CFN
+
+Wait for completion by watching the Senza status output.
+
+.. code-block:: bash
+
+    $ senza status deploy-definition.yaml -W --region=eu-west-1
+
+or senza events:
+
+.. code-block:: bash
+
+    $ senza events deploy-definition.yaml 1 -W --region=eu-west-1
+
+.. Important::
+
+    In case of error go to your log provider, if you did not configure it.
+    Go in aws, EC2 service, find your instance, right click, Instance Settings, Get System Log.


### PR DESCRIPTION
@georghildebrand @hjacobs @mikkel 

This PR adds a simple walkthrough of a GPU hello-world example. The Dockerfile is currently in the: https://github.com/elezar/gpu-hello-world repository, but this should be moved for the public docs.

Currently, the output of `nvidia-smi` in the container is simply sent to stdout, which means that the user cannot see this from the syslogs. Is there a better way to do this, or is it ok to tell them to check the applicatoin.log?